### PR TITLE
Made SF cost support eq

### DIFF
--- a/sources/common/units/infantry.txt.patch
+++ b/sources/common/units/infantry.txt.patch
@@ -1,0 +1,8 @@
+165a166
+> 		    support_equipment = 20
+222a224
+> 		    support_equipment = 20
+280a283
+> 			support_equipment = 10
+336a340
+> 		    support_equipment = 20


### PR DESCRIPTION
Made SF cost support equipment
Marines and Paras - 20 per battalion, mountaineers - 10